### PR TITLE
auth service saga

### DIFF
--- a/services/auth_service/docker-compose.yaml
+++ b/services/auth_service/docker-compose.yaml
@@ -56,13 +56,15 @@ services:
       retries: 40
 
   rabbitmq:
-    image: rabbitmq:3-management
-    hostname: "auth_service-rmq"
+    image: "rabbitmq:3-management"
+    ports:
+      - "5672:5672"
+      - "15672:15672"
     environment:
       RABBITMQ_DEFAULT_USER: "user"
       RABBITMQ_DEFAULT_PASS: "password"
     volumes:
-      - "rabbitmq_data:/var/lib/rabbitmq"
+      - rabbitmq_data:/var/lib/rabbitmq
 
 volumes:
   auth-db-data:

--- a/services/auth_service/src/api.go
+++ b/services/auth_service/src/api.go
@@ -20,21 +20,21 @@ type APIServer struct {
 	listenAddr string
 	readStore  ReadStorage
 	writeStore WriteStorage
-	publisher  Publisher
+	messenger  Messenger
 }
 
 func NewAPIServer(
 	listenAddr string,
 	readStore ReadStorage,
 	writeStore WriteStorage,
-	publisher Publisher,
+	messenger Messenger,
 ) *APIServer {
 
 	return &APIServer{
 		listenAddr: listenAddr,
 		readStore:  readStore,
 		writeStore: writeStore,
-		publisher:  publisher,
+		messenger:  messenger,
 	}
 }
 
@@ -199,7 +199,7 @@ func (s *APIServer) handleRegisterUser(w http.ResponseWriter, r *http.Request) e
 		Username: user.Username,
 	}
 
-	s.publisher.PublishUserCreated(publishData)
+	s.messenger.PublishUserCreated(publishData)
 
 	return WriteJSON(w, http.StatusCreated, DefaultCreatedResponse{ID: user.ID})
 }
@@ -242,7 +242,7 @@ func (s *APIServer) handleLoginEmail(w http.ResponseWriter, r *http.Request) err
 // @Success 200 {object} APISuccess
 // @Router /api/v1/health [get]
 func (s *APIServer) handleHealthCheck(w http.ResponseWriter, _ *http.Request) error {
-	s.publisher.PublishUserCreated(&CreateUserPublish{
+	s.messenger.PublishUserCreated(&CreateUserPublish{
 		ID:       uuid.New(),
 		Username: "yoyoyo",
 	})

--- a/services/auth_service/src/main.go
+++ b/services/auth_service/src/main.go
@@ -38,18 +38,24 @@ func main() {
 		log.Fatal(err)
 	}
 
-	publisher, err := NewRabbitMQPublisher(
+	messenger, err := NewRMQMessenger(
 		LoadRabbitMQConfig(),
 	)
 	if err != nil {
 		log.Fatal(err)
 	}
 
+	e := messenger.SubscribeUserCreatedError(writeStore)
+	if e != nil {
+		log.Fatal(e)
+	}
+
 	server := NewAPIServer(
 		":8080",
 		readStore,
 		writeStore,
-		publisher,
+		messenger,
 	)
 	server.Run()
+
 }

--- a/services/auth_service/src/storage_write.go
+++ b/services/auth_service/src/storage_write.go
@@ -11,6 +11,7 @@ import (
 type WriteStorage interface {
 	CreateUser(*User) error
 	DeleteUser(uuid.UUID) error
+	HardDeleteUser(uuid.UUID) error
 }
 
 type PostgresStoreWrite struct {
@@ -80,5 +81,14 @@ func (s *PostgresStoreWrite) DeleteUser(id uuid.UUID) error {
 	`
 
 	_, err := s.db.Exec(query, id, time.Now().UTC())
+	return err
+}
+
+func (s *PostgresStoreWrite) HardDeleteUser(id uuid.UUID) error {
+	query := `
+		DELETE FROM users WHERE id = $1
+	`
+
+	_, err := s.db.Exec(query, id)
 	return err
 }


### PR DESCRIPTION
Basically, it will listen for messages from the `new_user_error_queue` queue, where the message should have the format:
```json
{
	"user_id": "75590ee4-906c-4711-bc08-b7977a4117f3",
	"user_name": "test"
}
```
So in the relation service, you should send this data to the queue if any error happens in the creation process. This will then hard delete the created user.